### PR TITLE
Hiyokoクラスに，指定したマスにそのHiyokoが移動可能であるかをtrue/falseで返すcanMove()メソッドを追加する．

### DIFF
--- a/Hiyoko.pde
+++ b/Hiyoko.pde
@@ -3,4 +3,14 @@ class Hiyoko extends AbstractKoma {
   Hiyoko(String name, int x, int y, int team, boolean active) {
     super(name, x, y, team, active);
   }
+  
+  boolean canMove(int toX, int toY) {
+
+    if (!board.bArea.isInThisArea(toX,toY)) return false;
+
+    if (this.team == 0 && toX-this.x==1 && toY-this.y==0) return true;
+    else if (this.team == 1 && this.x-toX==1 && toY-this.y==0) return true;
+
+    return false;
+  }
 }


### PR DESCRIPTION
canMove()メソッドでは下記の条件をチェックし，true/falseを返す
移動先の座標(toX, toY)がBaseArea内でなければfalseを返す
Hiyokoは前方1マスにのみ移動できるため，Left側/Right側それぞれの場合において，移動先が現在のコマの場所の1コマ先である場合のみtrueを返す 上記の条件をどれも満たさない場合はfalseを返す